### PR TITLE
Fix client navigation not triggering content change

### DIFF
--- a/src/templates/storyblok-entry.js
+++ b/src/templates/storyblok-entry.js
@@ -2,11 +2,25 @@ import React from 'react'
 import Components from '../components/components.js'
 
 class StoryblokEntry extends React.Component {
+  static getDerivedStateFromProps(props, state) {
+    if (state.story.uuid === props.pathContext.story.uuid) {
+      return null
+    }
+
+    return StoryblokEntry.prepareStory(props)
+  }
+
+  static prepareStory(props) {
+    const story = Object.assign({}, props.pathContext.story)
+    story.content = JSON.parse(story.content)
+    
+    return { story }
+  }
+
   constructor(props) {
     super(props)
-    let story = Object.assign({}, props.pathContext.story)
-    story.content = JSON.parse(story.content)
-    this.state = {story: story}
+
+    this.state = StoryblokEntry.prepareStory(props)
   }
 
   render() {


### PR DESCRIPTION
Previously, when somebody clicked a gatsby link on the page, the URL would change but the content would not. The `StoryblokEntry` component dictates which storyblok page to render. However, its state was never updated in response to a change in its props, which would occur when client side navigation changed the page to be rendered. As the state stayed the same, so would the page contents.