### PR TITLE
fix: assign correct argument in sbEditable at 404

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -21,7 +21,7 @@ const NotFoundPage = ({ location }) => {
   return (
   <Layout>
     <Seo title="Home" />
-    <div {...sbEditable(story)} content={story ? story.content : false }>
+    <div {...sbEditable(story ? story.content : false)}>
       <h1>{ story ? story.content.title : 'Not Found' }</h1>
       { components }
       <StaticImage


### PR DESCRIPTION
404 page was broken.
Fixed to assign correct argument in `sbEditable` at `pages/404.js`