### PR TITLE
Remove preview token from public component

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -6,7 +6,7 @@ import Grid from "./grid"
 import Feature from "./feature"
 
 storyblokInit({
-  accessToken: process.env.GATSBY_PREVIEW_STORYBLOK,
+  accessToken: process.env.GATSBY_PUBLIC_STORYBLOK,
   use: [apiPlugin],
   components: {
     teaser: Teaser,


### PR DESCRIPTION
# Remove Preview Token From Public Component

From your documentation at https://www.storyblok.com/docs/api/content-delivery/v2#core-resources/stories/stories

> Public and Preview tokens are read only and do not allow you or others to write or delete entries in your space. The public token can be published.

There is no mention that `preview tokens` can be published and to me that is correct. You should not have the preview token in a public component as someone could use that to see unpublished content. 

IMHO, you should not have any of the access tokens available on the front end and all of the access tokens should be hidden by an API service layer or only available at build time. I would also recommend that this project does not use the naming convention `GATSBY_` as that naming convention is reserved for variables that are supposed to go into the front end. https://www.gatsbyjs.com/docs/how-to/local-development/environment-variables/#accessing-environment-variables-in-the-browser
